### PR TITLE
Use static require for code bundlers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Check code syntax
-          command: npm run lint -- --plugin log-filenames
+          command: npm run lint
   test:
     <<: *defaults
     steps:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,9 @@ module.exports = {
 		node: true,
 		es6: true,
 	},
+	plugins: [
+		'log',
+	],
 	extends: 'eslint:recommended',
 	rules: {
 		indent: [

--- a/lib/formatter/index.js
+++ b/lib/formatter/index.js
@@ -1,9 +1,8 @@
-const { join } = require('path');
 const isNumber = require('is-number');
 const sanitiser = require('../sanitiser');
 const types = require('../types');
 const letterLeading = string => /^[a-zA-Z]/.test(string);
-const SCHEMES_DIRETORY = join('..', '..', 'schemes');
+const schemes = require('../../schemes');
 
 /**
  * Creates a configured format function
@@ -29,12 +28,15 @@ module.exports = function formatter({prefix, sanitise = sanitiser, scheme = 'dat
 	}
 
 	if (typeof scheme === 'string') {
-		try {
-			scheme = require(join(SCHEMES_DIRETORY, scheme));
-		} catch (error) {
-			error.message = `Could not find ${scheme} scheme. ${error.message}`;
-			throw error;
+		if (schemes.hasOwnProperty(scheme)) {
+			scheme = schemes[scheme];
+		} else {
+			throw new Error(`Could not find ${scheme} scheme.`);
 		}
+	}
+
+	if (typeof scheme !== 'function') {
+		throw new Error(`Requiring scheme function (${scheme}).`);
 	}
 
 	const sanitiseKeys = object => Object.entries(object)

--- a/lib/formatter/spec.js
+++ b/lib/formatter/spec.js
@@ -1,22 +1,26 @@
-const formatter = require('.');
 const stubs = {};
+let formatter;
+
+function clean() {
+	delete require.cache[require.resolve('../../schemes/datadog')];
+	delete require.cache[require.resolve('../../schemes/graphite')];
+	delete require.cache[require.resolve('../../schemes')];
+}
 
 describe('formatter', () => {
 	let format;
-	let datadog;
-	let graphite;
+	let schemas;
 	before(() => {
-		datadog = require('../../schemes/datadog');
-		graphite = require('../../schemes/graphite');
-		require.cache[require.resolve('../../schemes/datadog')].exports = (...args) => stubs.datadog(...args);
-		require.cache[require.resolve('../../schemes/graphite')].exports = (...args) => stubs.graphite(...args);
+		schemas = require('../../schemes');
+		require.cache[require.resolve('../../schemes')].exports = {
+			datadog: (...args) => stubs.datadog(...args),
+			graphite: (...args) => stubs.graphite(...args),
+		};
+		formatter = require('.');
 		format = formatter();
 	});
-	beforeEach(() => Object.assign(stubs, {datadog, graphite}));
-	after(() => {
-		delete require.cache[require.resolve('../../schemes/datadog')];
-		delete require.cache[require.resolve('../../schemes/graphite')];
-	});
+	beforeEach(() => Object.assign(stubs, schemas));
+	after(clean);
 	it(
 		'Should throw error when metric name is not a string',
 		() => [
@@ -84,16 +88,16 @@ describe('formatter', () => {
 		['histogram', 'h'],
 	].forEach(
 		([full, symbol]) => {
-			let t;
-			const format = formatter({
-				scheme: ({type}) => {
-					t = type;
-				},
-			});
-
 			it(
 				`Should map type ${full} to symbol ${symbol}`,
 				() => {
+					let t;
+					const format = formatter({
+						scheme: ({type}) => {
+							t = type;
+						},
+					});
+
 					t = null;
 					format(full, 'hello', undefined);
 					expect(t).to.equal(symbol);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/statsd-client",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "📈 A feature packed, highly customisable StatsD client",
   "keywords": [
     "StatsD",
@@ -37,7 +37,7 @@
     "chai": "^4.2.0",
     "chai-string": "^1.5.0",
     "eslint": "^5.15.0",
-    "eslint-plugin-log-filenames": "^1.0.2",
+    "eslint-plugin-log": "^1.0.0",
     "mocha": "^6.0.2"
   }
 }

--- a/schemes/index.js
+++ b/schemes/index.js
@@ -1,0 +1,7 @@
+const datadog = require('./datadog');
+const graphite = require('./graphite');
+
+module.exports = {
+	datadog,
+	graphite,
+};


### PR DESCRIPTION
Use static module require. Webpack and code bundlers do not handle dynamic imports well. This solution is simple and the cost of requiring both modules in advance is cheap.