### PR TITLE
Add details to errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,10 +132,10 @@ class SDC {
 
         if (rate) {
             if (typeof rate !== 'number') {
-                throw betterror(new TypeError(`Expected 'rate' to be a number, instead got ${rate} (${typeof rate})`), { args });
+                throw betterror(new TypeError(`Expected 'rate' to be a number, instead got ${rate} (${typeof rate})`), { type, key, value, rate, tags });
             }
             if (rate > 1) {
-                throw betterror(new TypeError(`Expected 'rate' to be a number between 0 and 1, instead got ${rate}`), { args });
+                throw betterror(new TypeError(`Expected 'rate' to be a number between 0 and 1, instead got ${rate}`), { type, key, value, rate, tags });
             }
 
             if (this.enforceRate && !sample(rate)) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const sample = require('sample-size');
+const betterror = require('./lib/betterror');
 const flush = require('./lib/flush');
 const formatter = require('./lib/formatter');
 const push = require('./lib/push');
@@ -131,10 +132,10 @@ class SDC {
 
         if (rate) {
             if (typeof rate !== 'number') {
-                throw new TypeError(`Expected 'rate' to be a number, instead got ${rate} (${typeof rate})`);
+                throw betterror(new TypeError(`Expected 'rate' to be a number, instead got ${rate} (${typeof rate})`), { args });
             }
             if (rate > 1) {
-                throw new TypeError(`Expected 'rate' to be a number between 0 and 1, instead got ${rate}`);
+                throw betterror(new TypeError(`Expected 'rate' to be a number between 0 and 1, instead got ${rate}`), { args });
             }
 
             if (this.enforceRate && !sample(rate)) {

--- a/lib/betterror/index.js
+++ b/lib/betterror/index.js
@@ -5,11 +5,11 @@
  * @return {void}
  */
 module.exports = function betterror(error, details) {
-  if (details && typeof details === 'object') {
-    error.details = Object.assign(
-      error.details || {},
-      details
-    );
-  }
-  return error;
+    if (details && typeof details === 'object') {
+        error.details = Object.assign(
+            error.details || {},
+            details
+        );
+    }
+    return error;
 };

--- a/lib/betterror/index.js
+++ b/lib/betterror/index.js
@@ -1,0 +1,15 @@
+/**
+ * Mutate: enrich error with details
+ * @param  {Error}    error
+ * @param  {...any} arguments
+ * @return {void}
+ */
+module.exports = function betterror(error, details) {
+  if (details && typeof details === 'object') {
+    error.details = Object.assign(
+      error.details || {},
+      details
+    );
+  }
+  return error;
+};

--- a/lib/betterror/spec.js
+++ b/lib/betterror/spec.js
@@ -1,0 +1,26 @@
+const betterror = require('.');
+
+describe('betterror', () => {
+  it('Should return the original error', () => {
+    const error = new Error('Something must have gone terribly wrong');
+    expect(betterror(error)).to.equal(error);
+  });
+  it('Should not a "details" field when not applicable', () => {
+    const error = betterror(new Error('Something must have gone terribly wrong'));
+    expect(error).to.not.have.keys(['details']);
+  });
+  it('Should add a "details" field when applicable', () => {
+    const error = betterror(new Error('Something must have gone terribly wrong'), { a: 1 });
+    expect(error).to.have.keys(['details']);
+  });
+  it('Should add "details" to error', () => {
+    const error = betterror(new Error('Something must have gone terribly wrong'), { a: 1 });
+    expect(error.details).to.deep.equal({ a: 1 });
+  });
+  it('Should assign details if there is are some already', () => {
+    const err = new Error('Something must have gone terribly wrong');
+    err.details = { a: 1 };
+    const error = betterror(err, { b: 2 });
+    expect(error.details).to.deep.equal({ a: 1,  b: 2  });
+  });
+});

--- a/lib/betterror/spec.js
+++ b/lib/betterror/spec.js
@@ -1,26 +1,26 @@
 const betterror = require('.');
 
 describe('betterror', () => {
-  it('Should return the original error', () => {
-    const error = new Error('Something must have gone terribly wrong');
-    expect(betterror(error)).to.equal(error);
-  });
-  it('Should not a "details" field when not applicable', () => {
-    const error = betterror(new Error('Something must have gone terribly wrong'));
-    expect(error).to.not.have.keys(['details']);
-  });
-  it('Should add a "details" field when applicable', () => {
-    const error = betterror(new Error('Something must have gone terribly wrong'), { a: 1 });
-    expect(error).to.have.keys(['details']);
-  });
-  it('Should add "details" to error', () => {
-    const error = betterror(new Error('Something must have gone terribly wrong'), { a: 1 });
-    expect(error.details).to.deep.equal({ a: 1 });
-  });
-  it('Should assign details if there is are some already', () => {
-    const err = new Error('Something must have gone terribly wrong');
-    err.details = { a: 1 };
-    const error = betterror(err, { b: 2 });
-    expect(error.details).to.deep.equal({ a: 1,  b: 2  });
-  });
+    it('Should return the original error', () => {
+        const error = new Error('Something must have gone terribly wrong');
+        expect(betterror(error)).to.equal(error);
+    });
+    it('Should not a "details" field when not applicable', () => {
+        const error = betterror(new Error('Something must have gone terribly wrong'));
+        expect(error).to.not.have.keys(['details']);
+    });
+    it('Should add a "details" field when applicable', () => {
+        const error = betterror(new Error('Something must have gone terribly wrong'), { a: 1 });
+        expect(error).to.have.keys(['details']);
+    });
+    it('Should add "details" to error', () => {
+        const error = betterror(new Error('Something must have gone terribly wrong'), { a: 1 });
+        expect(error.details).to.deep.equal({ a: 1 });
+    });
+    it('Should assign details if there is are some already', () => {
+        const err = new Error('Something must have gone terribly wrong');
+        err.details = { a: 1 };
+        const error = betterror(err, { b: 2 });
+        expect(error.details).to.deep.equal({ a: 1, b: 2 });
+    });
 });

--- a/lib/formatter/index.js
+++ b/lib/formatter/index.js
@@ -63,13 +63,13 @@ module.exports = function formatter({prefix, sanitise = sanitiser, scheme = 'dat
         if (type in types) {
             type = types[type];
         } else {
-            throw betterror(new RangeError(`Expected 'type' to be one of ${Object.keys(types).join(', ')}, instead got ${type}`), { args: { type, key, value, rate, tags } });
+            throw betterror(new RangeError(`Expected 'type' to be one of ${Object.keys(types).join(', ')}, instead got ${type}`), { type, key, value, rate, tags });
         }
         if (typeof key !== 'string') {
-            throw betterror(new TypeError(`Expected 'key' to be a string, instead got ${key} (${typeof key})`), { args: { type, key, value, rate, tags } });
+            throw betterror(new TypeError(`Expected 'key' to be a string, instead got ${key} (${typeof key})`), { type, key, value, rate, tags });
         }
         if (!prefix && !letterLeading(key)) {
-            throw betterror(new Error(`Expected 'key' to start with an alphabetical character (${key}).`), { args: { type, key, value, rate, tags } });
+            throw betterror(new Error(`Expected 'key' to start with an alphabetical character (${key}).`), { type, key, value, rate, tags });
         }
         if (value instanceof Date) {
             value = new Date() - value;
@@ -78,7 +78,7 @@ module.exports = function formatter({prefix, sanitise = sanitiser, scheme = 'dat
             value = Number(process.hrtime.bigint() - value) / 1e6;
         }
         if (typeof value !== 'number' || !isNumber(value)) {
-            throw betterror(new TypeError(`Expected 'value' to be a number, instead got ${value} (${typeof value})`), { args: { type, key, value, rate, tags } });
+            throw betterror(new TypeError(`Expected 'value' to be a number, instead got ${value} (${typeof value})`), { type, key, value, rate, tags });
         }
 
         if (prefix) {

--- a/lib/formatter/index.js
+++ b/lib/formatter/index.js
@@ -63,13 +63,13 @@ module.exports = function formatter({prefix, sanitise = sanitiser, scheme = 'dat
         if (type in types) {
             type = types[type];
         } else {
-            throw betterror(new RangeError(`Expected 'type' to be one of ${Object.keys(types).join(', ')}, instead got ${type}`), { args: [...arguments] });
+            throw betterror(new RangeError(`Expected 'type' to be one of ${Object.keys(types).join(', ')}, instead got ${type}`), { args: { type, key, value, rate, tags } });
         }
         if (typeof key !== 'string') {
-            throw betterror(new TypeError(`Expected 'key' to be a string, instead got ${key} (${typeof key})`), { args: [...arguments] });
+            throw betterror(new TypeError(`Expected 'key' to be a string, instead got ${key} (${typeof key})`), { args: { type, key, value, rate, tags } });
         }
         if (!prefix && !letterLeading(key)) {
-            throw betterror(new Error(`Expected 'key' to start with an alphabetical character (${key}).`), { args: [...arguments] });
+            throw betterror(new Error(`Expected 'key' to start with an alphabetical character (${key}).`), { args: { type, key, value, rate, tags } });
         }
         if (value instanceof Date) {
             value = new Date() - value;
@@ -78,7 +78,7 @@ module.exports = function formatter({prefix, sanitise = sanitiser, scheme = 'dat
             value = Number(process.hrtime.bigint() - value) / 1e6;
         }
         if (typeof value !== 'number' || !isNumber(value)) {
-            throw betterror(new TypeError(`Expected 'value' to be a number, instead got ${value} (${typeof value})`), { args: [...arguments] });
+            throw betterror(new TypeError(`Expected 'value' to be a number, instead got ${value} (${typeof value})`), { args: { type, key, value, rate, tags } });
         }
 
         if (prefix) {

--- a/lib/formatter/index.js
+++ b/lib/formatter/index.js
@@ -1,4 +1,5 @@
 const isNumber = require('is-number');
+const betterror = require('../betterror');
 const sanitiser = require('../sanitiser');
 const types = require('../types');
 
@@ -62,13 +63,13 @@ module.exports = function formatter({prefix, sanitise = sanitiser, scheme = 'dat
         if (type in types) {
             type = types[type];
         } else {
-            throw new RangeError(`Expected 'type' to be one of ${Object.keys(types).join(', ')}, instead got ${type}`);
+            throw betterror(new RangeError(`Expected 'type' to be one of ${Object.keys(types).join(', ')}, instead got ${type}`), { args: [...arguments] });
         }
         if (typeof key !== 'string') {
-            throw new TypeError(`Expected 'key' to be a string, instead got ${key} (${typeof key})`);
+            throw betterror(new TypeError(`Expected 'key' to be a string, instead got ${key} (${typeof key})`), { args: [...arguments] });
         }
         if (!prefix && !letterLeading(key)) {
-            throw new Error(`Expected 'key' to start with an alphabetical character (${key}).`);
+            throw betterror(new Error(`Expected 'key' to start with an alphabetical character (${key}).`), { args: [...arguments] });
         }
         if (value instanceof Date) {
             value = new Date() - value;
@@ -77,7 +78,7 @@ module.exports = function formatter({prefix, sanitise = sanitiser, scheme = 'dat
             value = Number(process.hrtime.bigint() - value) / 1e6;
         }
         if (typeof value !== 'number' || !isNumber(value)) {
-            throw new TypeError(`Expected 'value' to be a number, instead got ${value} (${typeof value})`);
+            throw betterror(new TypeError(`Expected 'value' to be a number, instead got ${value} (${typeof value})`), { args: [...arguments] });
         }
 
         if (prefix) {

--- a/lib/formatter/spec.js
+++ b/lib/formatter/spec.js
@@ -75,7 +75,7 @@ describe('formatter', () => {
                 error = e;
             }
             console.log(error);
-            expect(error.details).to.deep.equal({ args: [ 'time', 'Hello', NaN ] });
+            expect(error.details).to.deep.equal({ type: 'ms', key: 'Hello', value: NaN, rate: undefined, tags: undefined });
         }
     );
     it(

--- a/lib/formatter/spec.js
+++ b/lib/formatter/spec.js
@@ -66,6 +66,19 @@ describe('formatter', () => {
         )
     );
     it(
+        'Should add details to errors',
+        () => {
+            let error;
+            try {
+                format('time', 'Hello', NaN);
+            } catch (e) {
+                error = e;
+            }
+            console.log(error);
+            expect(error.details).to.deep.equal({ args: [ 'time', 'Hello', NaN ] });
+        }
+    );
+    it(
         'Should default type to counter',
         () => {
             let t;
@@ -135,7 +148,8 @@ describe('formatter', () => {
         expect(time).to.be.a('number');
         expect(time).to.be.at.least(9);
     });
-    it('Should use a BigInt in order to get the time diff', async() => {
+    it('Should use a BigInt in order to get the time diff', async function() {
+        this.retries(3);
         let time;
         const format = formatter({scheme: ({value}) => {
             time = value;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/statsd-client",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "📈 A feature packed, highly customisable StatsD client",
   "keywords": [
     "StatsD",

--- a/test/spec.js
+++ b/test/spec.js
@@ -109,6 +109,7 @@ describe('Integration: bulk sending', () => {
 
             new Array(4).fill('a').forEach(client.count);
             expect(metrics).to.be.undefined;
+            await wait(5);
 
             client.flush();
             expect(metrics).to.be.instanceof(Buffer);


### PR DESCRIPTION
Currently, the error log offers little information when used via bundled code. See this private, bundled module's log for example 

```json
{
     "message"  :  "Expected 'value' to be a number, instead got NaN (number)" ,
     "name"  :  "TypeError" ,
     "columnNumber"  :  19 ,
     "lineNumber"  :  5504 ,
     "fileName"  :  "/app/node_modules/@fiverr-private/obs/dist/nodejs.js" ,
     "functionName"  :  "SDC.format" ,
     "source"  :  "    at SDC.format (/app/node_modules/@fiverr-private/obs/dist/nodejs.js:5504:19)" ,
     "stack"  :  "TypeError: Expected 'value' to be a number, instead got NaN (number)
    at SDC.format (/app/node_modules/@fiverr-private/obs/dist/nodejs.js:5504:19)
    at SDC.generic (/app/node_modules/@fiverr-private/obs/dist/nodejs.js:1466:18)
    at SDC.value [as time] (/app/node_modules/@fiverr-private/obs/dist/nodejs.js:1493:37)
    at action (/app/node_modules/@fiverr-private/obs/dist/nodejs.js:9462:59)
    at /app/node_modules/@fiverr-private/obs/dist/nodejs.js:9429:9
    at /app/node_modules/@fiverr-private/obs/dist/nodejs.js:8660:13
    at Set.forEach (<anonymous>)
    at EventBus.emit (/app/node_modules/@fiverr-private/obs/dist/nodejs.js:8659:30)
    at /app/node_modules/@fiverr-private/obs/dist/nodejs.js:8675:18
    at runMicrotasks (<anonymous>)"
}
```