### PR TITLE
Perform early range checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -142,6 +142,19 @@ class SDC {
             tags
         ] = spread(args);
 
+        if (!key) {
+            throw betterror(
+                new RangeError(`Expected 'key' to be a non empty string, instead found ${key} (${typeof key})`),
+                { type, key, value, rate, tags }
+            );
+        }
+        if (typeof value !== 'number' && Number(value) != value) { // eslint-disable-line eqeqeq
+            throw betterror(
+                new RangeError(`Expected 'value' to be a number, instead found ${key} (${typeof key})`),
+                { type, key, value, rate, tags }
+            );
+        }
+
         if (rate) {
             if (typeof rate !== 'number') {
                 throw betterror(

--- a/lib/send-tcp/index.js
+++ b/lib/send-tcp/index.js
@@ -14,7 +14,6 @@ let socket = null;
  */
 let closing = false;
 
-
 /**
  * Tear-down operation registered
  * @type {Boolean}

--- a/lib/send-udp/index.js
+++ b/lib/send-udp/index.js
@@ -69,7 +69,6 @@ function derefSocket() {
  */
 module.exports = function createSender(port, host, sockettype, errorHandler) {
 
-
     /**
      * Send data to UDP socket
      * @param {string} data

--- a/lib/sender/index.js
+++ b/lib/sender/index.js
@@ -42,4 +42,3 @@ module.exports = function sender({ host, port, protocol, protocol_version, error
 
     return sendUDP(port, host, sockettype, errorHandler);
 };
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/statsd-client",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "📈 A feature packed, highly customisable StatsD client",
   "keywords": [
     "StatsD",

--- a/spec.js
+++ b/spec.js
@@ -209,6 +209,14 @@ describe('SDC', () => {
         client.generic('count', 'a');
         expect(parameters.push).to.deep.equal(['some string']);
     });
+    it('Should throw error when no key is passed', () => {
+        client = new SDC();
+        expect(() => client.generic('count')).to.throw(RangeError);
+    });
+    it('Should throw error when non numeric value is passed', () => {
+        client = new SDC();
+        expect(() => client.generic('count', 'a', 'hi')).to.throw(RangeError);
+    });
     it('Should flush metrics before process exit', () => {
         const stats = new SDC();
         let flushed = false;


### PR DESCRIPTION
Early range check allow an error to be thrown in sync instead of down the line on the statsd stack, where it's harder to correlate with the function call.