### PR TITLE
Making json imports explicit, compatible with webpack 5.

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const formatter = require('./lib/formatter');
 const push = require('./lib/push');
 const sender = require('./lib/sender');
 const spread = require('./lib/spread');
-const types = require('./lib/types');
+const types = require('./lib/types/index.json');
 
 const TYPES_LIST = Object.keys(types);
 const TYPES = Object.freeze(

--- a/lib/formatter/index.js
+++ b/lib/formatter/index.js
@@ -1,7 +1,7 @@
 const isNumber = require('is-number');
 const betterror = require('../betterror');
 const sanitiser = require('../sanitiser');
-const types = require('../types');
+const types = require('../types/index.json');
 
 const letterLeading = (string) => /^[a-zA-Z]/.test(string);
 const schemes = require('../../schemes');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/statsd-client",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "📈 A feature packed, highly customisable StatsD client",
   "keywords": [
     "StatsD",


### PR DESCRIPTION
The types defined over `.json` file was imported without a suffix expecting to be resolved by webpack, which works for webpack 4. Looking towards webpack 5, we would need to explicitly specify none js files suffix.