### PR TITLE
Add option to override enforce rate per metric

### DIFF
--- a/docs/sections/metrics.md
+++ b/docs/sections/metrics.md
@@ -9,6 +9,7 @@ Exposes a client with the functions: `count`, `time`, `gauge`, `set`, `histogram
 | value | Number\|Date\|BigInt | 1 | The value to report †
 | options.rate | Number | - | Sample rate - a fraction of 1 (.01 is one percent)
 | options.tags | Object | - | Key-value pairs of tags set as object literal
+| options.enforceRate | Boolean | true | Override instance enforceRate option with this value
 
 > † If `value` if a Date - instance will send the time diff (`Date.now()`)
 >
@@ -81,6 +82,7 @@ stats.time(
       route: 'users/:user_id',
       status_code: 200,
     },
+    enforceRate: true,
   }
 );
 ```

--- a/index.js
+++ b/index.js
@@ -139,7 +139,8 @@ class SDC {
             key, // eslint-disable-line prefer-const
             value = 1, // eslint-disable-line prefer-const
             rate, // eslint-disable-line prefer-const
-            tags
+            tags,
+            enforceRate = true
         ] = spread(args);
 
         if (rate) {
@@ -156,7 +157,7 @@ class SDC {
                 );
             }
 
-            if (this.enforceRate && !sample(rate)) {
+            if (enforceRate && this.enforceRate && !sample(rate)) {
                 return this.size;
             }
         }

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ class SDC {
             value = 1, // eslint-disable-line prefer-const
             rate, // eslint-disable-line prefer-const
             tags,
-            enforceRate = true
+            enforceRate = true // eslint-disable-line prefer-const
         ] = spread(args);
 
         if (rate) {

--- a/lib/spread/index.js
+++ b/lib/spread/index.js
@@ -1,10 +1,11 @@
 /**
  * Extract all required arguments from dynamic structure
- * @param  {String} args[0]      type
- * @param  {String} args[1]      key
- * @param  {Number} args[2]      value
- * @param  {Number} args[3].rate rate
- * @param  {Object} args[3].tags tags
+ * @param  {String}  args[0]             type
+ * @param  {String}  args[1]             key
+ * @param  {Number}  args[2]             value
+ * @param  {Number}  args[3].rate        rate
+ * @param  {Object}  args[3].tags        tags
+ * @param  {Boolean} args[3].enforceRate enforceRate
  * @return {Array}
  *
  * @example spread('count', 'metric', 3, {rate: .1, tags: {...tags}}) ['count', 'metric', 3, .1, {...tags}]
@@ -12,14 +13,14 @@
  * @example spread('count', 'metric', {rate: .1, tags: {...tags}}) ['count', 'metric', undefined, .1, {...tags}]
  */
 module.exports = function spread(args) {
-    let type, key, value, rate, tags;
+    let type, key, value, rate, tags, enforceRate;
     const lastArg = args.pop();
 
     if (typeof lastArg === 'object') {
-        ({ rate, tags } = lastArg);
+        ({ rate, tags, enforceRate } = lastArg);
         ([type, key, value] = args);
     } else {
         ([type, key, value] = [...args, lastArg]);
     }
-    return [type, key, value, rate, tags];
+    return [type, key, value, rate, tags, enforceRate];
 };

--- a/lib/spread/spec.js
+++ b/lib/spread/spec.js
@@ -3,30 +3,30 @@ const spread = require('.');
 describe('spread', () => {
     it('Should extract args structure into an array', () => {
         expect(
-            spread(['type', 'key', 'value', { rate: 'rate', tags: 'tags' }])
+            spread(['type', 'key', 'value', { rate: 'rate', tags: 'tags', enforceRate: true }])
         ).to.deep.equal(
-            ['type', 'key', 'value', 'rate', 'tags']
+            ['type', 'key', 'value', 'rate', 'tags', true]
         );
     });
     it('Should retrieve options', () => {
         expect(
             spread(['type', 'key', 'value'])
         ).to.deep.equal(
-            ['type', 'key', 'value', undefined, undefined]
+            ['type', 'key', 'value', undefined, undefined, undefined]
         );
     });
     it('Should treat last arg as options', () => {
         expect(
-            spread(['type', 'key', { rate: 'rate', tags: 'tags' }])
+            spread(['type', 'key', { rate: 'rate', tags: 'tags', enforceRate: false }])
         ).to.deep.equal(
-            ['type', 'key', undefined, 'rate', 'tags']
+            ['type', 'key', undefined, 'rate', 'tags', false]
         );
     });
     it('Should fill in everything else as undefined', () => {
         expect(
             spread(['type', 'key'])
         ).to.deep.equal(
-            ['type', 'key', undefined, undefined, undefined]
+            ['type', 'key', undefined, undefined, undefined, undefined]
         );
     });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/statsd-client",
-  "version": "1.1.0-rc",
+  "version": "1.1.0",
   "description": "📈 A feature packed, highly customisable StatsD client",
   "keywords": [
     "StatsD",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/statsd-client",
-  "version": "1.0.9",
+  "version": "1.1.0-rc",
   "description": "📈 A feature packed, highly customisable StatsD client",
   "keywords": [
     "StatsD",

--- a/spec.js
+++ b/spec.js
@@ -168,6 +168,12 @@ describe('SDC', () => {
         client.generic('count', 'a', 1, { rate: 0.4 });
         expect(called.push).to.be.true;
     });
+    it('Should override with local enforceRate', () => {
+        client = new SDC({ enforceRate: true });
+        stubs.sample = () => true;
+        client.generic('count', 'a', 1, { rate: 0.1, enforceRate: false });
+        expect(called.push).to.be.true;
+    });
     it('Should skip when sample is false', () => {
         client = new SDC();
         stubs.sample = () => false;


### PR DESCRIPTION
Example
```js
client.count('my_metric', 1, { rate: .1, enforceRate: false })
```