### PR TITLE
fix: replace is-number dependency with a one liner

### DIFF
--- a/lib/formatter/index.js
+++ b/lib/formatter/index.js
@@ -1,4 +1,4 @@
-const isNumber = require('is-number');
+const isNumber = (num) => (typeof num === "number" && num - num === 0) || (typeof num === "string" && Number.isFinite(+num) && num.trim() !== "");
 const betterror = require('../betterror');
 const sanitiser = require('../sanitiser');
 const types = require('../types');

--- a/lib/formatter/index.js
+++ b/lib/formatter/index.js
@@ -1,4 +1,3 @@
-const isNumber = (num) => (typeof num === "number" && num - num === 0) || (typeof num === "string" && Number.isFinite(+num) && num.trim() !== "");
 const betterror = require('../betterror');
 const sanitiser = require('../sanitiser');
 const types = require('../types');
@@ -83,7 +82,7 @@ module.exports = function formatter({ prefix, sanitise = sanitiser, scheme = 'da
         if (typeof value === 'bigint') {
             value = Number(process.hrtime.bigint() - value) / 1e6;
         }
-        if (typeof value !== 'number' || !isNumber(value)) {
+        if (typeof value !== 'number' || value - value !== 0) {
             throw betterror(new TypeError(`Expected 'value' to be a number, instead got ${value} (${typeof value})`), { type, key, value, rate, tags });
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fiverr/statsd-client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "📈 A feature packed, highly customisable StatsD client",
   "keywords": [
     "StatsD",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,6 @@
     "test": "mocha 'spec.js' '**/spec.js' --require .mocha",
     "lint": "eslint '.*.js' '*.js' '**/*.js'"
   },
-  "dependencies": {
-    "is-number": "^7.0.0"
-  },
   "devDependencies": {
     "@fiverr/eslint-config-fiverr": "^3.2.4",
     "@lets/wait": "^2.0.2",


### PR DESCRIPTION
This PR replaces is-number package with a one liner with identical code.
This change reduces the unpacked size by a third and making it dependency free.
